### PR TITLE
Try not to Block On Syncrounous Calls

### DIFF
--- a/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestInvoker.cs
+++ b/src/xunit.execution/Sdk/Frameworks/Runners/XunitTestInvoker.cs
@@ -116,13 +116,20 @@ namespace Xunit.Sdk
 
         async Task<decimal> InvokeTimeoutTestMethodAsync(object testClassInstance)
         {
-            var baseTask = base.InvokeTestMethodAsync(testClassInstance);
+            var baseTask = InvokeBaseTestMethodAfterYieldForSyncronousCallSupport(testClassInstance);
             var resultTask = await Task.WhenAny(baseTask, Task.Delay(TestCase.Timeout));
 
             if (resultTask != baseTask)
                 throw new TestTimeoutException(TestCase.Timeout);
 
             return baseTask.Result;
+        }
+
+        async Task<decimal> InvokeBaseTestMethodAfterYieldForSyncronousCallSupport(object testClassInstance)
+        {
+            await Task.Yield();
+
+            return await base.InvokeTestMethodAsync(testClassInstance);
         }
     }
 }


### PR DESCRIPTION
- Added async method that yields before calling the test method.
This hopefully frees the current execution path and allows the Task.Delay Timeout to run and work.